### PR TITLE
Interactive EQ plot (drag/select markers) + UI highlighting

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,12 @@
+# Features & WIP
+
+Document features and the current work-in-progress modules:
+
+- `Spectrum Analyzer` — functional, connects to DSP spectrum stream
+- `Room EQ` — visual node editor (WIP — front-end UI present, no backend persistence)
+- `Interactive EQ graph on Basic/Equalizer pages` — functional, click to grab a filter, drag to adjust it, shift drag to adjust Q.
+- `UX smell` — Basic page and equalizer page don't show elements exactly the same way. fix that.
+- `Code Bug` — Check console errors when using extreme values.
+- `Orphaned Code` — The '/Views/' folder is not used. Remove it.
+- `UX improvement` — Consider implementing 'Shift+drag'. Users with track pads & magic mouse will be grateful.
+

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,7 +5,7 @@ Document features and the current work-in-progress modules:
 - `Spectrum Analyzer` — functional, connects to DSP spectrum stream
 - `Room EQ` — visual node editor (WIP — front-end UI present, no backend persistence)
 - `Interactive EQ graph on Basic/Equalizer pages` — functional, click to grab a filter, drag to adjust it, shift drag to adjust Q.
-- `UX smell` — Basic page and equalizer page don't show elements exactly the same way. fix that.
+- ~~`Interactive EQ`UX smell` — Basic page and equalizer page don't show elements exactly the same way. fix that.~~ Fixed
 - `Code Bug` — Check console errors when using extreme values.
 - `Orphaned Code` — The '/Views/' folder is not used. Remove it.
 - `UX improvement` — Consider implementing 'Shift+drag'. Users with track pads & magic mouse will be grateful.

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,7 +4,7 @@ Document features and the current work-in-progress modules:
 
 - `Spectrum Analyzer` — functional, connects to DSP spectrum stream
 - `Room EQ` — visual node editor (WIP — front-end UI present, no backend persistence)
-- `Interactive EQ graph on Basic/Equalizer pages` — functional, click to grab a filter, drag to adjust it, shift drag to adjust Q.
+- ~~``Interactive EQ graph on Basic/Equalizer pages` — functional, click to grab a filter, drag to adjust it, shift drag to adjust Q.~~
 - ~~`Interactive EQ`UX smell` — Basic page and equalizer page don't show elements exactly the same way. fix that.~~ Fixed
 - `Code Bug` — Check console errors when using extreme values.
 - `Orphaned Code` — The '/Views/' folder is not used. Remove it.

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,7 +4,7 @@ Document features and the current work-in-progress modules:
 
 - `Spectrum Analyzer` — functional, connects to DSP spectrum stream
 - `Room EQ` — visual node editor (WIP — front-end UI present, no backend persistence)
-- `Interactive EQ graph on Basic/Equalizer pages` — functional, click to grab a filter, drag to adjust it, shift drag to adjust Q.
+- ~~`Interactive EQ graph on Basic/Equalizer pages` — functional, click to grab a filter, drag to adjust it, shift drag to adjust Q.~~
 - ~~`Interactive EQ`UX smell` — Basic page and equalizer page don't show elements exactly the same way. fix that.~~ Fixed
 - `Code Bug` — Check console errors when using extreme values.
 - `Orphaned Code` — The '/Views/' folder is not used. Remove it.

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,4 +9,5 @@ Document features and the current work-in-progress modules:
 - `Code Bug` — Check console errors when using extreme values.
 - `Orphaned Code` — The '/Views/' folder is not used. Remove it.
 - `UX improvement` — Consider implementing 'Shift+drag'. Users with track pads & magic mouse will be grateful.
+- `resetPEQ` — The reset button on the equalizer page doesn't work. There is no implementation of it other than a stub somewhere.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -65,6 +65,8 @@ Simple tone controls for quick adjustments:
 
 Each tone control provides ±12 dB of adjustment using shelving/peaking filters.
 
+**Interactive graph:** Click a tone marker on the graph to select it. Drag to adjust frequency/gain. Hold **Shift** while dragging to adjust **Q**.
+
 #### Saving Basic Configurations
 
 1. Click the **Manage Configurations** icon in the toolbar
@@ -83,7 +85,9 @@ Each tone control provides ±12 dB of adjustment using shelving/peaking filters.
 
 ![Equalizer](../public/img/equalizer.png)
 
-Advanced parametric equalizer with visual frequency response:
+Advanced parametric equalizer with visual frequency response.
+
+**Interactive graph:** Click a filter marker on the graph to select the corresponding filter. Drag to adjust frequency/gain; **Shift+drag** adjusts Q.
 
 #### Adding Filters
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -356,6 +356,12 @@ select {
     background: hsl(var(--bck), 30%, 70%);   
     border: 0px solid 333;    
     box-shadow: 0px 0px 5px 0px hsl(var(--bck), 30%, 70%); 
+    transition: all 250ms ease;
+}
+
+.knob.is-selected {
+    box-shadow: 0px 0px 15px 3px hsl(var(--bck), 50%, 80%);
+    transform: scale(1.1);
 }
 
 .knob::before {
@@ -499,9 +505,17 @@ select {
     align-items: center;    
     user-select: none;
     border:1px solid hsl(var(--bck-hue), 20%, 30%);        
-    border-radius: 7px;            
+    border-radius: 7px;
+    transition: all 250ms ease;
 }
 
+.peqElement.is-selected {
+    border: 2px solid hsl(var(--bck-hue), 60%, 60%);
+    box-shadow: 0px 0px 20px 3px hsl(var(--bck-hue), 50%, 40%);
+    background: linear-gradient(90deg, 
+        hsla(var(--bck-hue), 40%, 22%, 0.6),
+        hsla(var(--bck-hue), 35%, 15%, 0.3));
+}
 
 .peqElement:hover {        
     filter: saturate(1.15) brightness(1.15);

--- a/public/src/basic.js
+++ b/public/src/basic.js
@@ -106,7 +106,11 @@ function updateElementWidth() {
     const ctx = document.getElementById('plotCanvas');    
     DSP = window.parent.DSP;            
     
-    canvas.width = basicControls.getBoundingClientRect().width;
+    // Compute canvas horizontal padding from CSS to ensure visual width alignment
+    const canvasStyle = getComputedStyle(canvas);
+    const paddingX = parseFloat(canvasStyle.paddingLeft) + parseFloat(canvasStyle.paddingRight);
+    
+    canvas.width = basicControls.getBoundingClientRect().width - paddingX;
     plotConfig();
 }
 

--- a/public/src/basic.js
+++ b/public/src/basic.js
@@ -165,6 +165,15 @@ function plotConfig() {
     const context = canvas.getContext('2d');             
 	context.clearRect(0, 0, canvas.width, canvas.height);        	
     
+    // Define which filters are tone controls (should have markers)
+    const BASIC_TONE_FILTERS = new Set([
+        '__subBass', '__bass', '__mids', '__upperMids', '__treble'
+    ]);
+    
+    // Filter functions to scope markers to tone controls only
+    const markerFilter = (filterName, filterDef) => BASIC_TONE_FILTERS.has(filterName);
+    const interactiveFilter = (filterName, filterDef) => BASIC_TONE_FILTERS.has(filterName);
+    
     if (window.parent.activeSettings.peqDualChannel) {
         let colors = ["#B55","#55B","#5B5","#F33","#33F","#3F3"]
         let channelCount = DSP.getChannelCount();
@@ -174,14 +183,23 @@ function plotConfig() {
             for (let filter of filterList) {     
                 channelFilters[filter]=DSP.config.filters[filter];
             }
-            plot(channelFilters,canvas,DSP.config.title,colors[channelNo]);
+            // Only show markers for first channel to avoid duplication
+            plot(channelFilters, canvas, DSP.config.title, colors[channelNo], channelNo, {
+                markerFilter: channelNo === 0 ? markerFilter : () => false,
+                interactiveFilter: channelNo === 0 ? interactiveFilter : () => false,
+                appendMarkers: channelNo > 0,
+                drawGrid: channelNo === 0
+            });
         }
 
     } else {
         let hue = (Math.abs((parseInt(window.parent.activeSettings.backgroundHue) + 10 )) % 360) /360;        
         let color = hslToRgb(hue, 0.3, 0.3);
         let colorNum = (color[0]+color[1]*255+color[2]*255*255);
-        plot(DSP.config.filters,canvas,DSP.config.title,colorNum);            
+        plot(DSP.config.filters, canvas, DSP.config.title, colorNum, undefined, {
+            markerFilter: markerFilter,
+            interactiveFilter: interactiveFilter
+        });            
     }    
 }
 

--- a/public/src/basic.js
+++ b/public/src/basic.js
@@ -1,7 +1,10 @@
 
-
-async function basicLoad() {       
-    
+/**
+ * Initialize and load the basic equalizer interface with controls and tone settings
+ * Sets up knobs, loads DSP configuration, attaches event listeners, and enables interactive plot markers
+ * @returns {Promise<void>} Promise that resolves when initialization is complete
+ */
+async function basicLoad() {
     const basicControls = document.getElementById('basicControls');
     const ctx = document.getElementById('plotCanvas');    
 
@@ -100,8 +103,13 @@ async function basicLoad() {
     }
 }
 
+/**
+ * Update canvas width to match control container and redraw the plot
+ * Ensures canvas visual width aligns properly by accounting for CSS padding
+ * @returns {void}
+ */
 function updateElementWidth() {
-    const basicControls = document.getElementById("basicControls");       
+    const basicControls = document.getElementById("basicControls");
     const canvas = document.getElementById("plotCanvas");           
     const ctx = document.getElementById('plotCanvas');    
     DSP = window.parent.DSP;            
@@ -114,8 +122,13 @@ function updateElementWidth() {
     plotConfig();
 }
 
+/**
+ * Load volume, balance, crossfeed, and tone control data from DSP config
+ * Initializes tone filters if they don't exist and updates UI knobs to reflect current values
+ * @returns {Promise<void>} Promise that resolves when data loading and plotting is complete
+ */
 async function loadData() {
-    const ctx = document.getElementById('plotCanvas');    
+    const ctx = document.getElementById('plotCanvas');
     DSP = window.parent.DSP;            
     
 
@@ -160,8 +173,13 @@ async function loadData() {
     plotConfig();
 }
 
+/**
+ * Plot the EQ frequency response curve with tone control markers on the canvas
+ * Handles both single and dual-channel modes with appropriate marker filtering for basic tone controls
+ * @returns {void}
+ */
 function plotConfig() {
-    const canvas = document.getElementById("plotCanvas");        
+    const canvas = document.getElementById("plotCanvas");
     const context = canvas.getContext('2d');             
 	context.clearRect(0, 0, canvas.width, canvas.height);        	
     
@@ -203,6 +221,11 @@ function plotConfig() {
     }    
 }
 
+/**
+ * Update tone control filter gains from knob values and upload to DSP
+ * Skips execution during drag operations to avoid conflicts with interactive marker updates
+ * @returns {Promise<void>} Promise that resolves when tone values are updated and uploaded
+ */
 async function setTone() {
     // Guard against running during drag to avoid conflicts
     if (window.__eqplotDragInProgress) {
@@ -239,6 +262,11 @@ const  freq = ['25', '30', '40', '50', '63', '80', '100', '125', '160', '200', '
 '3.1K', '4K', '5K', '6.3K', '8K', '10K', '12K', '16K', '20K']
 
 
+/**
+ * Initialize and render the audio spectrum analyzer display with animated level bars
+ * Creates DOM elements for frequency bands and starts a 100ms polling interval to fetch and visualize spectrum data
+ * @returns {Promise<void>} Promise that resolves when spectrum UI is initialized and update loop is started
+ */
 async function initSpectrum(){          
     // Create bars and boxes
     const spec = document.getElementById("spectrum");   
@@ -293,6 +321,11 @@ async function initSpectrum(){
     },100)
 }
 
+/**
+ * Set up interactive marker dragging on the EQ plot canvas
+ * Imports eqplot module, enables interaction, and wires up event handlers for marker drag with throttled plot updates and debounced DSP uploads
+ * @returns {void}
+ */
 function setupPlotInteraction() {
     const canvas = document.getElementById("plotCanvas");
     
@@ -314,7 +347,11 @@ function setupPlotInteraction() {
         '__treble': window.treble
     };
     
-    // Throttled plot update using requestAnimationFrame
+    /**
+     * Schedule a throttled plot update using requestAnimationFrame
+     * Prevents redundant redraws by ensuring only one pending update at a time
+     * @returns {void}
+     */
     function scheduleThrottledPlot() {
         if (plotTimer) return;
         plotTimer = requestAnimationFrame(() => {
@@ -323,7 +360,11 @@ function setupPlotInteraction() {
         });
     }
     
-    // Debounced DSP upload
+    /**
+     * Schedule a debounced DSP config upload with 100ms delay
+     * Prevents excessive uploads during continuous parameter changes by resetting the timer on each call
+     * @returns {void}
+     */
     function scheduleDSPUpload() {
         clearTimeout(uploadTimer);
         uploadTimer = setTimeout(() => {
@@ -385,6 +426,14 @@ function setupPlotInteraction() {
 
 const { abs, min, max, round } = Math;
 
+/**
+ * Convert HSL color values to RGB array
+ * Handles both chromatic and achromatic color conversions for use in canvas plotting
+ * @param {number} h - Hue value (0-1 normalized)
+ * @param {number} s - Saturation value (0-1)
+ * @param {number} l - Lightness value (0-1)
+ * @returns {Array<number>} Array of [r, g, b] values (0-255)
+ */
 function hslToRgb(h, s, l) {
     let r, g, b;
   
@@ -401,6 +450,14 @@ function hslToRgb(h, s, l) {
     return [round(r * 255), round(g * 255), round(b * 255)];
   }
   
+  /**
+   * Helper function to convert hue to RGB component value
+   * Implements the HSL-to-RGB conversion algorithm for a single color component
+   * @param {number} p - Calculated p value from HSL conversion
+   * @param {number} q - Calculated q value from HSL conversion
+   * @param {number} t - Adjusted hue value for the specific color component
+   * @returns {number} RGB component value (0-1)
+   */
   function hueToRgb(p, q, t) {
     if (t < 0) t += 1;
     if (t > 1) t -= 1;

--- a/public/src/eqplot.js
+++ b/public/src/eqplot.js
@@ -155,11 +155,12 @@ function plotArray(canvas, array, col, lineWidth){
 	ctx.lineWidth = lineWidth;
 	ctx.setLineDash([]);
 
-	let stepSize = (w - textMargin) / (array.length + 1 );
 	const heightScale= 16.5; 
 	
-	for (let i=0;i<array.length;i++) {            		
-		x=  textMargin + i * stepSize;								
+	for (let i=0;i<array.length;i++) {
+		// Convert array index to frequency, then frequency to X coordinate
+		const freq = indexToFreq(i, array.length);
+		x = freqToX(freq, w);
 		y = ch-(heightScale* array[i][1]);
 		ctx.lineTo(x,y);				
 	}        
@@ -294,6 +295,20 @@ function createGrid(canvas) {
 }
 
 /**
+ * Convert array index to frequency (Hz) based on the logarithmic scale used in calculateFilterDataMatrix
+ * @param {number} idx - Array index
+ * @param {number} len - Total array length
+ * @returns {number} Frequency in Hz
+ */
+function indexToFreq(idx, len) {
+	// This matches the frequency calculation in calculateFilterDataMatrix
+	// w ranges from 0.001 to 1 (normalized to Nyquist frequency)
+	const w = Math.exp(Math.log(1 / 0.001) * idx / (len - 1)) * 0.001;
+	// Convert normalized frequency to actual frequency (sampleRate/2 = 20000 Hz)
+	return w * 20000;
+}
+
+/**
  * Convert frequency (Hz) to canvas X coordinate using logarithmic scale
  * @param {number} freq - Frequency in Hz
  * @param {number} canvasWidth - Total canvas width
@@ -336,7 +351,7 @@ function drawFilterMarker(ctx, freq, gain, q, color, options = {}) {
 	const dotRadius = options.dotRadius || 6;
 	const qLineHeight = options.qLineHeight || 8;
 	const minQLineWidth = options.minQLineWidth || 30;
-	const maxQLineWidth = options.maxQLineWidth || 80;
+	const maxQLineWidth = options.maxQLineWidth || 250;
 	
 	// Calculate canvas coordinates
 	const x = freqToX(freq, ctx.canvas.width);

--- a/public/src/eqplot.js
+++ b/public/src/eqplot.js
@@ -295,7 +295,7 @@ function createGrid(canvas) {
 }
 
 /**
- * Generate a palette of visually distinct colors based on the number of types
+ * Generate a palette of visually distinct colors based on the number of filter types
  * @param {number} count - Number of colors needed
  * @returns {Array<string>} Array of color hex strings
  */

--- a/public/src/eqplot.js
+++ b/public/src/eqplot.js
@@ -1,17 +1,60 @@
-
-
+/**
+ * Constant: QUADLEN
+ * Description: This constant defines the number of points calculated in the frequency response calculation.
+ * Usage: Used in functions like `calculateFilterDataMatrix` to determine the length of arrays that store frequency response data.
+ */
 const QUADLEN = 2048;
 
-const textMargin=40;
-const leftMargin=35;
+/**
+ * Constant: textMargin
+ * Description: Defines the margin used for text placement, particularly for labeling axes.
+ * Usage: Applied in canvas drawing functions, such as `createGrid`, to offset text labels from the edges of the canvas for clarity.
+ */
+const textMargin = 40;
 
-const verticalDBRange= 30;
+/**
+ * Constant: leftMargin
+ * Description: Margin space used as a buffer on the left side of the canvas to accommodate labels or axes.
+ * Usage: Used in functions like `createGrid` and `freqToX`, helping to position elements correctly relative to the left edge of the canvas.
+ */
+const leftMargin = 35;
 
-// Constants for coordinate mapping
+/**
+ * Constant: verticalDBRange
+ * Description: Number of vertical steps for drawing dB scale on the canvas.
+ * Usage: Utilized in `createGrid` to determine the number of horizontal grid lines based on decibels, facilitating visual scaling of gain values.
+ */
+const verticalDBRange = 30;
+
+/**
+ * Constant: MIN_FREQ
+ * Description: The minimum frequency (in Hz) considered in the logarithmic frequency mapping.
+ * Usage: Used in functions like `freqToX` to set bounds for frequency mapping, ensuring calculations start from this base frequency.
+ */
 const MIN_FREQ = 20;
+
+/**
+ * Constant: MAX_FREQ
+ * Description: The maximum frequency (in Hz) considered in the logarithmic frequency mapping.
+ * Usage: Paired with MIN_FREQ in mapping functions (`freqToX` and `xToFreq`) for setting upper bounds on frequency calculations and drawings.
+ */
 const MAX_FREQ = 20000;
+
+/**
+ * Constant: HEIGHT_SCALE
+ * Description: Multiplier for converting gain (in dB) to Y-coordinates on the canvas.
+ * Usage: Applied in functions like `plotArray` and `drawFilterMarker` to translate dB gain values into corresponding vertical positions on the plot.
+ */
 const HEIGHT_SCALE = 16.5;
 
+/**
+ * Calculate the filter data matrix for different filter types with given frequency, gain, and Q factor.
+ * @param {string} type - The type of filter (e.g., "Lowpass", "Highshelf").
+ * @param {number} freq - The frequency at which the filter operates.
+ * @param {number} gain - The gain value in decibels for the filter.
+ * @param {number} qfact - The quality factor for the filter.
+ * @returns {Array<Array<number>>} Magnitude plot array consisting of frequency and gain pairs.
+ */
 function calculateFilterDataMatrix(type, freq, gain, qfact) {	
 	let sampleRate=40000;
 	let a0,a1,a2,b1,b2,norm;	
@@ -142,6 +185,14 @@ function calculateFilterDataMatrix(type, freq, gain, qfact) {
 	
 }
 
+/**
+ * Plot an array of frequency and gain values on the canvas.
+ * @param {HTMLCanvasElement} canvas - The canvas element to draw on.
+ * @param {Array<Array<number>>} array - The array containing frequency and gain pairs.
+ * @param {string} col - The color used for the plot line (hex or color name).
+ * @param {number} lineWidth - The width of the plot line.
+ * @returns {Object} The color and lineWidth used for plotting.
+ */
 function plotArray(canvas, array, col, lineWidth){       
 	let ctx = canvas.getContext("2d");
 	let h = canvas.height;    
@@ -168,6 +219,11 @@ function plotArray(canvas, array, col, lineWidth){
 	return {"color":col,"lineWidth":lineWidth};	
 }
 
+/**
+ * Create a grid with horizontal and vertical lines for additional visual reference.
+ * @param {HTMLCanvasElement} canvas - The canvas element to draw on.
+ * @returns {void}
+ */
 function createGridEx(canvas) {
 	let ctx = canvas.getContext("2d");
 
@@ -228,6 +284,11 @@ function createGridEx(canvas) {
 	
 }
 
+/**
+ * Create a grid on the canvas for better visualization of frequency and gain scales.
+ * @param {HTMLCanvasElement} canvas - The canvas element to draw on.
+ * @returns {void}
+ */
 function createGrid(canvas) {
 	let ctx = canvas.getContext("2d");
 	
@@ -448,6 +509,7 @@ function yToGain(y, canvasHeight) {
  * @param {number} options.qLineHeight - Height of Q-value delimiter lines (default: 8px)
  * @param {number} options.minQLineWidth - Minimum Q line width (default: 30px)
  * @param {number} options.maxQLineWidth - Maximum Q line width (default: 80px)
+ * @return {void}
  */
 function drawFilterMarker(ctx, freq, gain, q, color, options = {}) {
 	const dotRadius = options.dotRadius || 6;
@@ -504,6 +566,20 @@ function drawFilterMarker(ctx, freq, gain, q, color, options = {}) {
 	ctx.restore();
 }
 
+/**
+ * Main function to plot EQ filters on a canvas
+ * @param {Object} filterObject - Object containing filter definitions
+ * @param {HTMLCanvasElement} canvas - Canvas element to draw on	
+ * @param {string} name - Name of the filter to plot	
+ * @param {string} color - Color of the filter plot			
+ * @param {number} channelNo - Channel number (for multi-channel plots)								
+ * @param {Object} options - Additional options for plotting
+ * @param {Function} options.markerFilter - Function(filterName, filterDef) => boolean to show marker
+ * @param {Function} options.interactiveFilter - Function(filterName, filterDef) => boolean to make interactive
+ * @param {boolean} options.appendMarkers - Append to existing markers (multi-channel)
+ * @param {boolean} options.drawGrid - Draw grid (disable for multi-channel overlays)
+ * @returns {Array<Array<number>>} Total response array
+ */
 function plot(filterObject, canvas, name, color, channelNo, options = {}) {
 	// Default options
 	const {

--- a/public/src/equalizer.js
+++ b/public/src/equalizer.js
@@ -128,8 +128,13 @@ function updateElementWidth() {
     const barWidth= (spec.getBoundingClientRect().width - (barCount*6)) / barCount;
     document.documentElement.style.setProperty("--levelbar-width",barWidth+"px") 
     
-    const canvas = document.getElementById("plotCanvas");           
-    canvas.width = spec.getBoundingClientRect().width - 20;
+    const canvas = document.getElementById("plotCanvas");
+    
+    // Compute canvas horizontal padding from CSS to ensure visual width alignment
+    const canvasStyle = getComputedStyle(canvas);
+    const paddingX = parseFloat(canvasStyle.paddingLeft) + parseFloat(canvasStyle.paddingRight);
+    
+    canvas.width = spec.getBoundingClientRect().width - paddingX;
     plotConfig();
 }
 

--- a/public/src/equalizer.js
+++ b/public/src/equalizer.js
@@ -256,6 +256,11 @@ function plotConfig() {
     const context = canvas.getContext('2d');             
 	context.clearRect(0, 0, canvas.width, canvas.height);        	
     
+    // Filter function: only show markers for PEQ filters (exclude system filters starting with __)
+    const isPEQFilter = (filterName, filterDef) => {
+        return filterDef?.type === 'Biquad' && !filterName.startsWith('__');
+    };
+    
     if (window.parent.activeSettings.peqDualChannel) {
         let colors = ["#B55","#55B","#5B5","#F33","#33F","#3F3"]
         let channelCount = DSP.getChannelCount();
@@ -265,7 +270,13 @@ function plotConfig() {
             for (let filter of filterList) {     
                 channelFilters[filter]=DSP.config.filters[filter];
             }
-            plot(channelFilters,canvas,DSP.config.title,colors[channelNo],channelNo);
+            // Accumulate markers across channels for multi-channel mode
+            plot(channelFilters, canvas, DSP.config.title, colors[channelNo], channelNo, {
+                markerFilter: isPEQFilter,
+                interactiveFilter: isPEQFilter,
+                appendMarkers: channelNo > 0,
+                drawGrid: channelNo === 0
+            });
         }
 
     } else {
@@ -273,7 +284,10 @@ function plotConfig() {
         // console.log("Start hue : ",window.parent.activeSettings.backgroundHue,hue*360,hue)
         let color = hslToRgb(hue, 0.3, 0.3);
         let colorNum = (color[0]+color[1]*255+color[2]*255*255);
-        plot(DSP.config.filters,canvas,DSP.config.title,colorNum);            
+        plot(DSP.config.filters, canvas, DSP.config.title, colorNum, undefined, {
+            markerFilter: isPEQFilter,
+            interactiveFilter: isPEQFilter
+        });            
     }    
 }
 

--- a/public/src/equalizer.js
+++ b/public/src/equalizer.js
@@ -12,6 +12,11 @@ interval = setInterval(function(){
 },100);
 
 
+/**
+ * Initialize and load the parametric equalizer interface with all controls
+ * Sets up knobs, loads filters from DSP config, creates filter UI elements, and enables interactive plot markers
+ * @returns {Promise<void>} Promise that resolves when initialization is complete
+ */
 async function equalizerOnLoad() {            
     document.loading=true;
     const PEQ = document.getElementById('PEQ');                
@@ -110,8 +115,6 @@ async function equalizerOnLoad() {
 
     const spec = document.getElementById("spectrum");
 
-    
-
     if(window.parent.activeSettings.showEqualizerSpectrum && window.parent.activeSettings.enableSpectrum) {        
         spec.style.display="grid";
         initSpectrum();    
@@ -122,8 +125,13 @@ async function equalizerOnLoad() {
     
 }
 
+/**
+ * Update canvas width and spectrum bar widths to match window dimensions
+ * Ensures proper visual alignment by recalculating widths and accounting for CSS padding
+ * @returns {void}
+ */
 function updateElementWidth() {
-    const spec = document.getElementById("spectrum");   
+    const spec = document.getElementById("spectrum");
     const barCount=spec.childNodes.length-1;
     const barWidth= (spec.getBoundingClientRect().width - (barCount*6)) / barCount;
     document.documentElement.style.setProperty("--levelbar-width",barWidth+"px") 
@@ -139,8 +147,13 @@ function updateElementWidth() {
 }
 
 
+/**
+ * Load all biquad filters from DSP config and create UI elements for each
+ * Handles single/dual channel modes by splitting or merging filters as needed and creates filter elements sorted by frequency
+ * @returns {Promise<void>} Promise that resolves when filters are loaded and UI is built
+ */
 async function loadFiltersFromConfig() {                        
-    PEQ.innerHTML='';                
+    PEQ.innerHTML='';
     
     await DSP.downloadConfig();
 
@@ -200,6 +213,12 @@ async function loadFiltersFromConfig() {
     await DSP.uploadConfig();
 }
 
+/**
+ * Create a UI element for a given filter with controls for type, subtype, parameters, and add/remove buttons
+ * Configures layout based on single-line or multi-line mode settings
+ * @param {Object} currentFilter - The filter object for which to create the UI element
+ * @returns {HTMLElement} The constructed filter UI element
+ */
 function createFilterElement(currentFilter) {
     // currentFilter.createElement(true);            
 
@@ -251,6 +270,11 @@ function createFilterElement(currentFilter) {
     return peqElement;
 }
 
+/** Plot the current DSP configuration on the canvas
+ * Supports single and dual channel modes with distinct colors for each channel
+ * Filters system filters and only displays parametric EQ (PEQ) filters
+ * @returns {void}
+ */
 function plotConfig() {
     const canvas = document.getElementById("plotCanvas");        
     const context = canvas.getContext('2d');             
@@ -291,6 +315,11 @@ function plotConfig() {
     }    
 }
 
+/** Set the preamp gain in the DSP configuration
+ * Adds a Gain filter if not already present and updates its gain parameter
+ * @param {number} gain - The desired preamp gain in dB
+ * @returns {void}
+ */
 function setPreamp(gain) {    
     if (DSP.config.filters.Gain == undefined) {        
         let gainFilter = {}
@@ -300,6 +329,9 @@ function setPreamp(gain) {
     DSP.config.filters.Gain.parameters.gain= Math.round(gain);                    
 }
 
+/** Sort all PEQ channel elements by filter frequency
+ * @returns {void}
+ */
 function sortAll() {
     const PEQs=document.getElementsByClassName("peqChannel");                        
     for (let PEQ of PEQs) {
@@ -307,6 +339,10 @@ function sortAll() {
     }
 }
 
+/** Sort child PEQ elements of a parent container by their filter frequency
+ * @param {HTMLElement} parent - The parent container whose child PEQ elements will be sorted
+ * @returns {void}
+ */
 function sortByFreq(parent) {    
     let elementArray=[];
     parent.childNodes.forEach(element => {                        
@@ -328,6 +364,10 @@ function sortByFreq(parent) {
     }            
 }
 
+/** Clear all PEQ filters from DSP configuration and UI
+ * Resets preamp gain to 0 dB and updates the plot
+ * @returns {Promise<void>} Promise that resolves when clearing is complete
+ */
 async function clearPEQ() {        
     setPreamp(0);
     DSP.clearFilters();       
@@ -338,6 +378,11 @@ async function clearPEQ() {
     plotConfig(); 
 }
 
+/** Add a new filter to the specified channel at the appropriate frequency
+ * Inserts the new filter UI element in sorted order and uploads to DSP
+ * @param {Event} e - The event triggering the addition, contains context for insertion point
+ * @returns {Promise<void>} Promise that resolves when the filter is added
+ */
 async function addNewFilter(e) {    
     // Create a filter object based on default filter 
     let newFilter = new window.filter(DSP);    
@@ -387,6 +432,11 @@ async function addNewFilter(e) {
     
 }
 
+/** Remove a filter from DSP configuration and UI
+ * Also removes from the other channel if dual channel mode is off
+ * @param {Event} e - The event triggering the removal, contains context for which filter to remove
+ * @returns {Promise<void>} Promise that resolves when the filter is removed
+ */
 async function removeFilter(e) {
     let peqChannel= e.target.parentElement;
     let channel = parseInt(peqChannel.getAttribute("channelno"));
@@ -408,10 +458,18 @@ function resetPEQ() {
     console.log("Reset needs to be re-implemented")
 }
 
+/** Frequencies for spectrum analyzer bars
+ * @type {string[]}
+ */
 const  freq = ['25', '30', '40', '50', '63', '80', '100', '125', '160', '200', '250',
 '315', '400', '500', '630', '800', '1K', '1.2K', '1.6K', '2K', '2.5K',
 '3.1K', '4K', '5K', '6.3K', '8K', '10K', '12K', '16K', '20K']
 
+/** Initialize the spectrum analyzer display with bars and boxes
+ * Sets up the visual elements and starts periodic updates to reflect audio spectrum data
+ * @param {Window} [parentWindow=window] - The parent window context for accessing settings and DOM
+ * @returns {Promise<void>} Promise that resolves when initialization is complete
+ */
 async function initSpectrum(parentWindow){         
     
     if (!window.parent.activeSettings.enableSpectrum) return;
@@ -483,6 +541,10 @@ async function initSpectrum(parentWindow){
 
 }
 
+/** Converts camillaNode v1 configurations to v2 configurations
+ * Fetches existing v1 configs, transforms them to v2 format, and saves them remotely
+ * @returns {Promise<void>} Promise that resolves when all configurations have been converted
+ */
 async function convertConfigs() {
     // Converts camillaNode v1 configurations to v2 configurations
 
@@ -537,6 +599,11 @@ async function convertConfigs() {
     }
 }
 
+/** Setup interactive plot marker dragging to adjust filter parameters
+ * Updates DSP configuration and UI input fields in real-time during marker drags
+ * Implements throttled plot updates and debounced DSP uploads for performance
+ * @returns {void}
+ */
 function setupPlotInteraction() {
     const canvas = document.getElementById("plotCanvas");
     
@@ -626,8 +693,12 @@ function setupPlotInteraction() {
     });
 }
 
-const { abs, min, max, round } = Math;
-
+/** Convert HSL color values to RGB
+ * @param {number} h - Hue component (0 to 1)
+ * @param {number} s - Saturation component (0 to 1)
+ * @param {number} l - Lightness component (0 to 1)
+ * @returns {number[]} Array containing RGB components [r, g, b] (0 to 255)
+ */
 function hslToRgb(h, s, l) {
     let r, g, b;
   
@@ -641,9 +712,19 @@ function hslToRgb(h, s, l) {
       b = hueToRgb(p, q, h - 1.0/3.0);
     }
   
-    return [round(r * 255), round(g * 255), round(b * 255)];
+    return [
+      Math.round(r * 255),
+      Math.round(g * 255),
+      Math.round(b * 255)
+    ];
   }
   
+  /** Helper function for HSL to RGB conversion
+   * @param {number} p - Temporary value
+   * @param {number} q - Temporary value
+   * @param {number} t - Temporary value
+   * @returns {number} RGB component value (0 to 1)
+   */
   function hueToRgb(p, q, t) {
     if (t < 0) t += 1;
     if (t > 1) t -= 1;

--- a/public/src/knob.js
+++ b/public/src/knob.js
@@ -51,9 +51,10 @@ class EQKnob {
                     }              
 
                     const valElement = knob.children[1];
-                    valElement.innerText=((val-31)/10)+offset;
+                    const displayValue = ((val-31)/10)+offset;
+                    valElement.innerText = Number(displayValue.toFixed(1));
                     valElement.style.opacity='1';
-                    setTimeout(function(e){e.style.opacity='0';},1000,valElement);     
+                    setTimeout(function(e){e.style.opacity='0';},1000,valElement);
                 }
             })
         })        
@@ -87,8 +88,10 @@ class EQKnob {
     }
 
     setVal(v) {
-        this.knobHeadDot.setAttribute("val",v);
-        return v;
+        const num = Number(v);
+        const clean = Number.isFinite(num) ? Math.round(num) : v;
+        this.knobHeadDot.setAttribute("val", clean);
+        return clean;
     }
 
 
@@ -98,4 +101,4 @@ class EQKnob {
 }
 
 
-export default EQKnob; 
+export default EQKnob;

--- a/public/src/knob.js
+++ b/public/src/knob.js
@@ -1,5 +1,6 @@
-
-
+/**
+ * Represents an equalizer knob component.
+ */
 class EQKnob {    
     #knobHeadDot; 
 
@@ -8,6 +9,13 @@ class EQKnob {
     defaultVal;
     offAtDefault=false;
 
+    /**
+     * Create an EQKnob.
+     * @param {string} label - The label for the knob.
+     * @param {number|string} val - The initial value of the knob.
+     * If '181', sets offset to -15.
+     * Sets knob's label attribute to the specified label.
+     */    
     constructor(label,val) {
         this.knob = document.createElement('div');
         const knobHead = document.createElement('div');
@@ -28,6 +36,7 @@ class EQKnob {
         if (val=="181") this.knobHeadDot.setAttribute("offset",-15);
         this.knob.setAttribute("label",label);
 
+        // Observe changes to knobHeadDot's attributes and update knob UI accordingly
         const observer = new MutationObserver(function(muts){
             muts.forEach(function(mut){                
                 if (mut.type=="attributes" && mut.attributeName=="val") {                    
@@ -83,10 +92,20 @@ class EQKnob {
         return this;
     }
 
+    /**
+     * Get the current value of the knob.
+     * @returns {string} The current value set on the knobHeadDot attribute.
+     */
     getVal() {
         return this.knobHeadDot.getAttribute("val");        
     }
 
+    /**
+     * Set the value of the knob.
+     * @param {number|string} v - The value to be set on the knob. 
+     * Rounds and applies if numeric, otherwise direct set.
+     * @returns {number|string} The processed value being set.
+     */
     setVal(v) {
         const num = Number(v);
         const clean = Number.isFinite(num) ? Math.round(num) : v;
@@ -94,11 +113,6 @@ class EQKnob {
         return clean;
     }
 
-
-
-
-
 }
-
 
 export default EQKnob;


### PR DESCRIPTION
### Summary

Adds interactive filter markers to the EQ plot on __Basic__ and __Equalizer__ pages. Markers can be selected and dragged to update filter params, with matching UI elements highlighted. Adds JSDoc to any file I touched in a effort to help clarify things. Also fixes canvas width sizing bug.

This is in follow up to the feature request in https://github.com/ismailAtaman/camillaNode/issues/5

### User-visible changes
- __Plot interaction__
  - Drag marker → adjust __freq + gain__
  - Shift+drag → adjust __Q__

- __Selection highlighting__
  - Marker ↔ UI selection is bidirectional:
    - Basic: highlights the matching __tone knob__
    - Equalizer: highlights the matching __PEQ card__ (dual-channel uses base name matching)

- __:bug: Fix EQ Canvas sizing__: width calculation now accounts for CSS padding (either equalizer or basic was off, can't remember which).

### Code changes

- __`public/src/eqplot.js`__
  - Extends `plot()` with options (markerFilter, interactiveFilter, multi-channel marker accumulation, selected state) to handle events and interactivity.
  - Stores marker metadata on the canvas (`canvas.__eqMarkers`).
  - Exports `enableEqPlotInteraction(canvas)` which hit-tests markers and emits events: `eqplot:marker-select`, `eqplot:marker-drag-*`
  - Adds inverse mapping helpers `xToFreq()` and `yToGain()` to get param values back from the canvas to the filters.

- __`public/src/basic.js`__
  - Enables plot interaction and scopes eqplot markers to tone controls only (`__subBass/__bass/__mids/__upperMids/__treble`).
  - Syncs marker selection with knob selection/highlighting
  - updates DSP config + input fields during drag.

- __`public/src/equalizer.js`__
  - Enables plot interaction and scopes eqplot markers to PEQ filters only (biquads not starting with `__`).
  - Syncs marker selection with PEQ card selection/highlighting; 
  - updates DSP config + input fields during drag.

- __`public/css/main.css`__: adds `.knob.is-selected` and `.peqElement.is-selected` styles.

- __`public/src/knob.js`__: rounds numeric `setVal()` and formats display to 1 decimal.

- __`docs/features.md`__: documents the interactive EQ work and follow-ups.

### Caveat emptor
- Multi-channel editing may need a second look. 
- There is no frequency constraint for the EQ plot drag events. That's a bit odd for those displayed on the __basic__ page.

I hope this feature is to your liking @ismailAtaman 